### PR TITLE
Added partial ROM decompression method, ie. getting amplitude and phase parameter space interpolants from SEOBNRv2_ROM LAL code and perform frequency space interpolation in compress.py

### DIFF
--- a/bin/pycbc_compress_bank
+++ b/bin/pycbc_compress_bank
@@ -40,56 +40,74 @@ from pycbc import filter
 
 parser = argparse.ArgumentParser(description=__description__)
 parser.add_argument("--bank-file", type=str,
-                help="Bank hdf file to load.")
+                    help="Bank hdf file to load.")
 parser.add_argument("--output", type=str,
-                help="The hdf file to save the templates and compressed "
-                     "waveforms to.")
+                    help="The hdf file to save the templates and compressed "
+                    "waveforms to.")
 parser.add_argument("--low-frequency-cutoff", type=float, required=True,
-                help="The low frequency cutoff to use for generating "
-                     "the waveforms (Hz)")
+                    help="The low frequency cutoff to use for generating "
+                    "the waveforms (Hz)")
 # add approximant arg
 pycbc.waveform.bank.add_approximant_arg(parser)
 parser.add_argument("--sample-rate", type=int, required=True,
-                help="Half this value sets the maximum frequency of the "
-                     "compressed waveforms.")
+                    help="Half this value sets the maximum frequency of the "
+                    "compressed waveforms.")
 parser.add_argument("--tmplt-index", nargs=2, type=int, default=None,
-                help="Only generate compressed waveforms for the given "
-                     "indices in the bank file. Must provide both a start "
-                     "and a stop index. Default is to compress all of the "
-                     "templates in the bank file.")
+                    help="Only generate compressed waveforms for the given "
+                    "indices in the bank file. Must provide both a start "
+                    "and a stop index. Default is to compress all of the "
+                    "templates in the bank file.")
+parser.add_argument("--ROM-parameter-space-interpolation", type=str,
+                    choices=["linear_compression", "partial_ROM_compression"],
+                    default="linear_compression",
+                    help="The method used to get the amplitude and phase"
+                    "interpolants and the corressponding amplitude and"
+                    "phase frequency points for the SEOBNRv2_ROM waveforms"
+                    "in the template bank. Choices are 'linear_compression'"
+                    "which would calculate the interpolants and frequency"
+                    "points in the compress_waveform function in compress.py,"
+                    "OR 'partial_rom_compression' which would call the"
+                    "LAL code for SEOBNRv2_ROM from the partial_compress_rom"
+                    "function of compress.py to get the interpolants and"
+                    "the frequency points")
 parser.add_argument("--compression-algorithm", type=str, required=True,
-                choices=compress.compression_algorithms.keys(),
-                help="The compression algorithm to use for selecting "
-                     "frequency points.")
+                    choices=compress.compression_algorithms.keys(),
+                    help="The compression algorithm to use for selecting "
+                    "frequency points for all TaylorF2 templates and"
+                    "SEOBNRv2_ROM templates when"
+                    " --ROM-parameter-space-interpolation is "
+                    "'linear_compression'. This would select a common "
+                    "set of frequency points for both amplitude "
+                    "and phase interpolants")
 parser.add_argument("--t-pad", type=float, default=0.001,
-                help="The minimum duration used for t(f) in seconds. The "
-                     "inverse of this gives the maximum frequency step that "
-                     "will be used in the compressed waveforms. Default is "
-                     "0.001.")
+                    help="The minimum duration used for t(f) in seconds. The "
+                    "inverse of this gives the maximum frequency step that "
+                    "will be used in the compressed waveforms. Default is "
+                    "0.001.")
 parser.add_argument("--tolerance", type=float, default=0.001,
-                help="The maximum mismatch to allow between the interpolated "
-                     "waveform must and the full waveform. Points will be "
-                     "added to the compressed waveform until its "
-                     "interpolation has a mismatch <= this value. Default is "
-                     "0.001.")
-parser.add_argument("--interpolation", type=str, 
-                default="linear",
-                help="The interpolation to use for decompressing the "
-                     "waveforms for checking tolerance. Options are "
-                     "'linear_same_freq_points', which assumes that the "
-                     "frequency samples of the amplitude and phase "
-                     "interpolants are the same, or any interpolation "
-                     "recognized by scipy's interp1d kind argument, which "
-                     "allows the frequency interpolant samples to be "
-                     "different for the amplitude and phase. "
-                     "Default is linear_same_freq_points.")
+                    help="The maximum mismatch to allow between the "
+                    "interpolated waveform and the full waveform. Points"
+                    "will be added to the compressed waveform until its "
+                    "interpolation has a mismatch <= this value."
+                    " Default is 0.001.")
+parser.add_argument("--interpolation", type=str,
+                    default="inline_linear",
+                    help="The interpolation to use for decompressing the "
+                    "waveforms for checking tolerance. Options are "
+                    "'inline_linear', which assumes that the "
+                    "frequency samples of the amplitude and phase "
+                    "interpolants are the same, or any interpolation "
+                    "recognized by scipy's interp1d kind argument, which "
+                    "allows the frequency interpolant samples to be "
+                    "different for the amplitude and phase. "
+                    "Default is inline_linear.")
 parser.add_argument("--precision", type=str, choices=["double", "single"],
-                default="double",
-                help="What precision to generate and store the waveforms with;"
-                     " default is double.")
+                    default="double",
+                    help="What precision to generate and store the"
+                    "waveforms with; default is double.")
 parser.add_argument("--force", action="store_true", default=False,
                     help="Overwrite the given hdf file if it exists. "
-                         "Otherwise, an error is raised.")
+                    "Otherwise, an error is raised.")
 parser.add_argument("--verbose", action="store_true", default=False)
 
 
@@ -111,7 +129,7 @@ else:
     dtype = numpy.complex128
 # we'll just use dummy values for N, df for now
 bank = waveform.FilterBank(args.bank_file, 5, 0.25, fmin, dtype,
-    approximant=args.approximant)
+                           approximant=args.approximant)
 templates = bank.table
 if args.tmplt_index is not None:
     imin, imax = args.tmplt_index
@@ -134,7 +152,6 @@ output = bank.write_to_hdf(args.output, force=args.force,
 
 # get the compressed sample points for each template
 logging.info("getting compressed amplitude and phase")
-mismatches = numpy.zeros(imax-imin, dtype=float)
 for ii in range(imin, imax):
     # update the N, df to use based on this waveform
     N = int(args.sample_rate*seg_lens[ii-imin])
@@ -142,33 +159,67 @@ for ii in range(imin, imax):
     bank.delta_f = df
     bank.N = N
     bank.filter_length = N/2 + 1
-    # We'll budge the waveform starting frequency down by 1df to ensure 
+    # We'll budge the waveform starting frequency down by 1df to ensure
     # the first point is correct
     bank.f_lower = fmin-df
     bank.kmin = int(bank.f_lower / df)
     # scratch space
     decomp_scratch = FrequencySeries(numpy.zeros(N, dtype=dtype), delta_f=df)
     # generate the waveform
-    htilde = bank[ii]
-    tmplt = bank.table[ii]
+    htilde = bank[ii-imin]
+    tmplt = bank.table[ii-imin]
     kmax = htilde.end_idx
-    
-    # get the compressed sample points
-    if args.compression_algorithm == 'mchirp':
-        sample_points = compress.mchirp_compression(tmplt.mass1, tmplt.mass2,
-            fmin, (kmax-1)*df, min_seglen=args.t_pad, df_multiple=df).astype(
-            real_same_precision_as(htilde))
-    elif args.compression_algorithm == 'spa':
-        sample_points = compress.spa_compression(htilde, fmin, (kmax-1)*df,
-            min_seglen=args.t_pad).astype(real_same_precision_as(htilde))
+
+    mtotal = tmplt.mass1 + tmplt.mass2
+    # Call the appropriate function in compress.py to get the compressed
+    # amplitude and phase frequency points and decompress them in
+    # frequency space :
+
+    # If template is SEOBNRv2_ROM perform linear_compression or
+    # partial_ROM_compression as per user input
+    if mtotal >= 4:
+        if args.ROM_parameter_space_interpolation == 'linear_compression':
+            if args.compression_algorithm == 'mchirp':
+                sample_points = compress.mchirp_compression(
+                    tmplt.mass1, tmplt.mass2, fmin, (kmax-1)*df,
+                    min_seglen=args.t_pad,
+                    df_multiple=df).astype(real_same_precision_as(htilde))
+            elif args.compression_algorithm == 'spa':
+                sample_points = compress.spa_compression(
+                    htilde, fmin, (kmax-1)*df, min_seglen=
+                    args.t_pad).astype(real_same_precision_as(htilde))
+            else:
+                raise ValueError("unrecognized compression algorithm %s" %(
+                             args.compression_algorithm))
+
+            hcompressed = compress.compress_waveform(
+                    htilde, sample_points, args.tolerance,
+                    args.interpolation, decomp_scratch=decomp_scratch)
+
+        elif args.ROM_parameter_space_interpolation == 'partial_ROM_compression':
+            hcompressed = compress.partial_compress_rom( htilde, tmplt.mass1,
+                tmplt.mass2, tmplt.spin1z, tmplt.spin2z, df, fmin,
+                (kmax-1)*df, args.interpolation)
+
+    # if template is a SPAtmplt waveform perform linear_compression
     else:
-        raise ValueError("unrecognized compression algorithm %s" %(
-            args.compression_algorithm))
-            
-    # compress
-    hcompressed = compress.compress_waveform( htilde, sample_points, 
-        args.tolerance, args.interpolation,
-        decomp_scratch=decomp_scratch)
+        if args.compression_algorithm == 'mchirp':
+            sample_points = compress.mchirp_compression(
+                tmplt.mass1, tmplt.mass2, fmin, (kmax-1)*df,
+                min_seglen=args.t_pad,
+                df_multiple=df).astype(real_same_precision_as(htilde))
+        elif args.compression_algorithm == 'spa':
+            sample_points = compress.spa_compression(
+                htilde, fmin, (kmax-1)*df, min_seglen=
+                args.t_pad).astype(real_same_precision_as(htilde))
+        else:
+            raise ValueError("unrecognized compression algorithm %s" %(
+                             args.compression_algorithm))
+
+        hcompressed = compress.compress_waveform(
+                    htilde, sample_points, args.tolerance,
+                    args.interpolation, decomp_scratch=decomp_scratch)
+
 
     # save results
     hcompressed.write_to_hdf(output, tmplt.template_hash)

--- a/pycbc/waveform/compress.py
+++ b/pycbc/waveform/compress.py
@@ -26,19 +26,21 @@ domain waveforms.
 import lalsimulation, lal, numpy, logging, h5py
 from pycbc import pnutils, filter
 from pycbc.opt import omp_libs, omp_flags
-from pycbc import WEAVE_FLAGS
+from pycbc import WEAVE_FLAGS, DYN_RANGE_FAC
 from scipy.weave import inline
 from scipy import interpolate
+from scipy.interpolate import splrep
 from pycbc.types import FrequencySeries, zeros, complex_same_precision_as, real_same_precision_as
 from pycbc.waveform import utils
 
 def rough_time_estimate(m1, m2, flow, fudge_length=1.1, fudge_min=0.02):
     """ A very rough estimate of the duration of the waveform.
 
-    An estimate of the waveform duration starting from flow. This is intended
-    to be fast but not necessarily accurate. It should be an overestimate of
-    the length. It is derived from a simplification of the 0PN post-newtonian
-    terms and includes a fudge factor for possible ringdown, etc.
+    An estimate of the waveform duration starting from flow. This is
+    intended to be fast but not necessarily accurate. It should be an
+    overestimate of the length. It is derived from a simplification of
+    the 0PN post-newtonian terms and includes a fudge factor for possible
+    ringdown, etc.
 
     Parameters
     ----------
@@ -66,7 +68,7 @@ def rough_time_estimate(m1, m2, flow, fudge_length=1.1, fudge_min=0.02):
         (numpy.pi * msun * flow) **  (8.0 / 3.0)
 
     # fudge factoriness
-    return .022 if t < 0 else (t + fudge_min) * fudge_length 
+    return .022 if t < 0 else (t + fudge_min) * fudge_length
 
 def mchirp_compression(m1, m2, fmin, fmax, min_seglen=0.02, df_multiple=None):
     """Return the frequencies needed to compress a waveform with the given
@@ -85,9 +87,9 @@ def mchirp_compression(m1, m2, fmin, fmax, min_seglen=0.02, df_multiple=None):
     min_seglen : float
         The inverse of this gives the maximum frequency step that is used.
     df_multiple : {None, float}
-        Make the compressed sampling frequencies a multiple of the given value.
-        If None provided, the returned sample points can have any floating
-        point value.
+        Make the compressed sampling frequencies a multiple of the given
+        value. If None provided, the returned sample points can have any
+        floating point value.
 
     Returns
     -------
@@ -167,8 +169,8 @@ def _vecdiff(htilde, hinterp, fmin, fmax):
                           normalized=False))
 
 def vecdiff(htilde, hinterp, sample_points):
-    """Computes a statistic indicating between which sample points a waveform
-    and the interpolated waveform differ the most.
+    """Computes a statistic indicating between which sample points a
+    waveform and the interpolated waveform differ the most.
     """
     vecdiffs = numpy.zeros(sample_points.size-1, dtype=float)
     for kk,thisf in enumerate(sample_points[:-1]):
@@ -178,35 +180,36 @@ def vecdiff(htilde, hinterp, sample_points):
 
 def compress_waveform(htilde, sample_points, tolerance, interpolation,
         decomp_scratch=None):
-    """Retrieves the amplitude and phase at the desired sample points, and adds
-    frequency points in order to ensure that the interpolated waveform
-    has a mismatch with the full waveform that is <= the desired tolerance. The
-    mismatch is computed by finding 1-overlap between `htilde` and the
-    decompressed waveform; no maximimization over phase/time is done, nor is
-    any PSD used.
-    
+    """Retrieves the amplitude and phase at the desired sample points,
+    and adds frequency points in order to ensure that the interpolated
+    waveform has a mismatch with the full waveform that is <= the desired
+    tolerance. The mismatch is computed by finding 1-overlap between
+    `htilde` and the decompressed waveform; no maximimization over
+    phase/time is done, nor is any PSD used.
+
     .. note::
-        The decompressed waveform is only garaunteed to have a true mismatch
-        <= the tolerance for the given `interpolation` and for no PSD.
-        However, since no maximization over time/phase is performed when
-        adding points, the actual mismatch between the decompressed waveform
-        and `htilde` is better than the tolerance, using no PSD. Using a PSD
-        does increase the mismatch, and can lead to mismatches > than the
-        desired tolerance, but typically by only a factor of a few worse.
+        The decompressed waveform is only garaunteed to have a true
+        mismatch <= the tolerance for the given `interpolation` and for
+        no PSD. However, since no maximization over time/phase is
+        performed when adding points, the actual mismatch between the
+        decompressed waveform and `htilde` is better than the tolerance,
+        using no PSD. Using a PSD does increase the mismatch, and can
+        lead to mismatches > than the desired tolerance, but typically
+        by only a factor of a few worse.
 
     Parameters
     ----------
     htilde : FrequencySeries
         The waveform to compress.
     sample_points : array
-        The frequencies at which to store the amplitude and phase. More points
-        may be added to this, depending on the desired tolerance.
+        The frequencies at which to store the amplitude and phase. More
+        points may be added to this, depending on the desired tolerance.
     tolerance : float
         The maximum mismatch to allow between a decompressed waveform and
         `htilde`.
     interpolation : str
-        The interpolation to use for decompressing the waveform when computing
-        overlaps.
+        The interpolation to use for decompressing the waveform when
+        computing overlaps.
     decomp_scratch : {None, FrequencySeries}
         Optionally provide scratch space for decompressing the waveform. The
         provided frequency series must have the same `delta_f` and length
@@ -232,19 +235,19 @@ def compress_waveform(htilde, sample_points, tolerance, interpolation,
     out = decomp_scratch
     amp_sample_points = None
     phase_sample_points = sample_points
-    hdecomp = fd_decompress(comp_amp, comp_phase, 
-        amp_sample_points, phase_sample_points,
-        out=decomp_scratch, df=outdf, f_lower=fmin,
-        interpolation=interpolation)
+    hdecomp = fd_decompress(comp_amp, comp_phase, amp_sample_points,
+                            phase_sample_points, out=decomp_scratch,
+                            df=outdf, f_lower=fmin,
+                            interpolation=interpolation)
     mismatch = 1. - filter.overlap(hdecomp, htilde, low_frequency_cutoff=fmin)
     if mismatch > tolerance:
-        # we'll need the difference in the waveforms as a function of frequency
+        # we'll need the difference in the waveforms as a function of
+        # frequency
         vecdiffs = vecdiff(htilde, hdecomp, sample_points)
-
     # We will find where in the frequency series the interpolated waveform
     # has the smallest overlap with the full waveform, add a sample point
     # there, and re-interpolate. We repeat this until the overall mismatch
-    # is > than the desired tolerance 
+    # is > than the desired tolerance
     added_points = []
     while mismatch > tolerance:
         minpt = vecdiffs.argmax()
@@ -263,27 +266,95 @@ def compress_waveform(htilde, sample_points, tolerance, interpolation,
         comp_phase = phase.take(sample_index)
         # update the vecdiffs and mismatch
         amp_sample_points = None
-        phase_sample_points = sample_points
-        hdecomp = fd_decompress(comp_amp, comp_phase, 
-            amp_sample_points, phase_sample_points,
-            out=decomp_scratch, df=outdf, f_lower=fmin,
-            interpolation=interpolation)
+	phase_sample_points = sample_points
+        hdecomp = fd_decompress(comp_amp, comp_phase, amp_sample_points,
+                                phase_sample_points, out=decomp_scratch,
+                                df=outdf, f_lower=fmin,
+                                interpolation=interpolation)
         new_vecdiffs = numpy.zeros(vecdiffs.size+1)
         new_vecdiffs[:minpt] = vecdiffs[:minpt]
         new_vecdiffs[minpt+2:] = vecdiffs[minpt+1:]
         new_vecdiffs[minpt:minpt+2] = vecdiff(htilde, hdecomp,
-            sample_points[minpt:minpt+2])
+                                              sample_points[minpt:minpt+2])
         vecdiffs = new_vecdiffs
         mismatch = 1. - filter.overlap(hdecomp, htilde,
-            low_frequency_cutoff=fmin)
+                                       low_frequency_cutoff=fmin)
         added_points.append(addidx)
     logging.info("mismatch: %f, N points: %i (%i added)" %(mismatch,
-        len(comp_amp), len(added_points)))
-    
+                 len(comp_amp), len(added_points)))
     return CompressedWaveform(amp_sample_points, phase_sample_points,
-                comp_amp, comp_phase,
-                interpolation=interpolation, tolerance=tolerance,
-                mismatch=mismatch)
+                              comp_amp, comp_phase,
+                              interpolation=interpolation,
+                              mismatch=mismatch, tolerance=tolerance)
+
+
+def partial_compress_rom(htilde, mass1, mass2, chi1, chi2, deltaF, fLow,
+                         fHigh, interpolation):
+    phiRef = 0
+    fRef = 0
+    # a suitable value for distance is provided for now
+    distance = float((1.0e6 * lal.PC_SI)/DYN_RANGE_FAC)
+    inclination = 0
+    # Convert the component masses from solar mass units to kg, because
+    # the function in the SEOBNRv2_ROM LAL code reads in masses in SI units
+    m1SI = mass1 * lal.MSUN_SI
+    m2SI = mass2 * lal.MSUN_SI
+    # Get the amplitude and phase interpolants and amplitude and phase
+    # frequency points from the SEOBNRv2_ROM LAL code
+    amp_interp_points, amp_freq_points, phase_interp_points, phase_freq_points = lalsimulation.SimIMRSEOBNRv2ROMDoubleSpinAmpPhaseInterpolants(
+            phiRef, deltaF, fLow, fHigh, fRef, distance, inclination,
+            m1SI, m2SI, float(chi1), float(chi2) )
+    amp_freq_points = numpy.asarray(amp_freq_points.data,
+                                    dtype=numpy.float32)
+    phase_freq_points = numpy.asarray(phase_freq_points.data,
+                                      dtype=numpy.float32)
+    amp_interp_points = numpy.asarray(amp_interp_points.data,
+                                      dtype=numpy.float32)
+    phase_interp_points = numpy.asarray(phase_interp_points.data,
+                                        dtype=numpy.float32)
+
+    Mtot = mass1+mass2
+    Mtot_sec = float(Mtot*lal.MTSUN_SI)
+    # The LAL code returns the frequency points in geometric units.
+    # Converting them into Hz by diving them by total mass of binary in
+    # secs
+    amp_freq_points = amp_freq_points/Mtot_sec
+    phase_freq_points = phase_freq_points/Mtot_sec
+    fmin_interp = max(amp_freq_points.min(), phase_freq_points.min())
+    fmax_interp = min(amp_freq_points.max(), phase_freq_points.max())
+    # Decompress the waveform in frequency space
+    hdecomp = fd_decompress(amp_interp_points, phase_interp_points,
+			    amp_freq_points, phase_freq_points, out=None,
+			    df=deltaF, f_lower=fmin_interp,
+                            interpolation=interpolation)
+    # Calculate the highest frequency point in the frequency series for
+    # the full decompresssed SEOBNRv2_ROM waveform (htilde) and the the
+    # highest frequency point in the frequency series partially
+    # decompressed SEOBNRv2_ROM waveform (hdecomp)
+    fmax_hdecomp = numpy.amax(hdecomp.sample_frequencies.numpy())
+    fmax_htilde = numpy.amax(htilde.sample_frequencies.numpy())
+    # Calculate the minimum of the highest frequency points for the two
+    # waveforms which would be used as a high_frequency_cutoff while
+    # calculating the mismatch between the two
+    high_frequency_cutoff = min(fmax_hdecomp, fmax_htilde)
+    # Calculate the mismatch between the two waveforms :
+    # The low_frequency_cutoff is the lower frequency point taken as user
+    # input in 'pycbc_compress_bank' for generating 'htilde'. The lengths
+    # of hdecomp and htilde are not the same. Therefore a
+    # high_frequency_cutoff which lies in the range of freqencies for
+    # htilde and hdecomp is provided and is calculated as described above.
+    # The mismatch is calculated for the length of the waveforms between
+    # the low_frequency_cutoff and high_frequency_cutoff.
+    mismatch = 1. - filter.overlap(abs(hdecomp), abs(htilde),
+                                   low_frequency_cutoff=fLow,
+                                   high_frequency_cutoff=high_frequency_cutoff)
+    logging.info("""mismatch: %.10f, for low_frequency_cutoff = %.1f and
+                 high_frequency_cutoff = %.1f"""%(mismatch, fLow,
+                 high_frequency_cutoff))
+    return CompressedWaveform(amp_freq_points, phase_freq_points,
+                              amp_interp_points, phase_interp_points,
+                              interpolation=interpolation,
+                              mismatch=mismatch)
 
 
 _linear_decompress_code = r"""
@@ -317,7 +388,7 @@ _linear_decompress_code = r"""
     double* outptr = (double*) h;
 
     // for keeping track of where in the output frequencies we are
-    int findex, next_sfindex, kmax; 
+    int findex, next_sfindex, kmax;
 
     // variables for computing the interpolation
     double df = (double) delta_f;
@@ -386,7 +457,7 @@ _linear_decompress_code = r"""
             // for the next update_interval steps, compute h by incrementing
             // the last h
             kmax = findex + update_interval;
-            if (kmax > next_sfindex) 
+            if (kmax > next_sfindex)
                 kmax = next_sfindex;
             while (findex < kmax){
                 incrh_re = h_re * dphi_re - h_im * dphi_im;
@@ -431,7 +502,7 @@ _real_dtypes = {
 }
 
 def fd_decompress(amp, phase, amp_freq, phase_freq, out=None, df=None,
-        f_lower=None, interpolation='linear'):
+                  f_lower=None, interpolation='inline_linear'):
     """Decompresses an FD waveform using the given amplitude, phase, and the
     frequencies at which they are sampled at.
 
@@ -443,26 +514,26 @@ def fd_decompress(amp, phase, amp_freq, phase_freq, out=None, df=None,
         The phase of the waveform at the sample frequencies.
     amp_freq : array
         The frequency (in Hz) of the waveform at the amplitude sample
-        frequencies.  
+        frequencies.
     phase_freq : array
-        The frequency (in Hz) of the waveform at the phase sample 
+        The frequency (in Hz) of the waveform at the phase sample
         frequencies.
     out : {None, FrequencySeries}
         The output array to save the decompressed waveform to. If this contains
         slots for frequencies > the maximum frequency in the interpolant
-        frequency arrays, the rest of the values are zeroed. If not provided, 
+        frequency arrays, the rest of the values are zeroed. If not provided,
         must provide a df.
     df : {None, float}
         The frequency step to use for the decompressed waveform. Must be
         provided if out is None.
     f_lower : {None, float}
         The frequency to start the decompression at. If None, will use whatever
-        the lowest frequency is of the interpolants in amplitude and phase. 
+        the lowest frequency is of the interpolants in amplitude and phase.
         All values at frequencies less than this will be 0 in the decompressed
         waveform.
     interpolation : {'linear_same_freq_points', str}
         The interpolation to use for the amplitude and phase. Default is
-        'linear_same_freq_points'. If 'linear_same_freq_points' a custom 
+        'linear_same_freq_points'. If 'linear_same_freq_points' a custom
         interpolater is used that assumes that the the frequency samples of
         the amplitude and phase interpolants are exactly the same. Otherwise,
         ``scipy.interpolate.interp1d`` is used; for other options, see
@@ -475,37 +546,31 @@ def fd_decompress(amp, phase, amp_freq, phase_freq, out=None, df=None,
         FrequencySeries with the decompressed waveform.
     """
     precision = _precision_map[phase_freq.dtype.name]
-    if interpolation == "linear":
-        if amp_freq != None:
-            raise ValueError("for inline_linear_single_freq decompression"
-                     "amp_freq should be set to None as it should be the"
-                     " same as phase_freq")
-        sample_frequencies = phase_freq
-        if _precision_map[amp.dtype.name] != precision or \
-               _precision_map[phase.dtype.name] != precision:
-           raise ValueError("amp, phase, and phase_freq must"
-                             " all have the same precision")
-        f_min = phase_freq.min()
-        f_max = phase_freq.max()   
-        
+    if amp_freq == None:
+    	if _precision_map[amp.dtype.name] != precision or \
+    		_precision_map[phase.dtype.name] != precision:
+    	    raise ValueError("amp, phase, and phase_freq must"
+    			     " all have the same precision")
+    	sample_frequencies = phase_freq
+    	f_min = phase_freq.min()
+    	f_max = phase_freq.max()
 
     else:
-        if _precision_map[amp.dtype.name] != precision or \
-               _precision_map[phase.dtype.name] != precision or \
-               _precision_map[amp_freq.dtype.name] != precision:
-           raise ValueError("amp, phase, amp_freq, and phase_freq must"
-                             " all have the same precision")
-
-        f_min = max([amp_freq.min(),phase_freq.min()])
-        f_max = min([amp_freq.max(),phase_freq.max()]) 
+    	if _precision_map[amp.dtype.name] != precision or \
+       	     _precision_map[phase.dtype.name] != precision or \
+    	    	_precision_map[amp_freq.dtype.name] != precision:
+            raise ValueError("amp, phase, amp_freq, and phase_freq must"
+			     "all have the same precision")
+    	f_min = max([amp_freq.min(),phase_freq.min()])
+    	f_max = min([amp_freq.max(),phase_freq.max()])
 
     if out is None:
         if df is None:
             raise ValueError("Either provide output memory or a df")
         hlen = int(numpy.ceil(f_max/df+1))
         out = FrequencySeries(numpy.zeros(hlen,
-            dtype=_complex_dtypes[precision]), copy=False,
-            delta_f=df)
+                              dtype=_complex_dtypes[precision]),
+                              copy=False, delta_f=df)
     else:
         # check for precision compatibility
         if out.precision == 'double' and precision == 'single':
@@ -514,37 +579,45 @@ def fd_decompress(amp, phase, amp_freq, phase_freq, out=None, df=None,
         hlen = len(out)
     if f_lower is None:
         imin = 0
-        f_lower = f_min
+	f_lower = f_min
     else:
-        if f_lower >= f_max:
+	if f_lower >= f_max:
             raise ValueError("f_lower is greater than the maximum "
                              "sample frequency of the interpolants")
     start_index = int(numpy.floor(f_lower/df))
     # interpolate the amplitude and the phase
-    if interpolation == "linear":
-        imin = int(numpy.searchsorted(sample_frequencies, f_lower))
-        if precision == 'single':
-            code = _linear_decompress_code32
-        else:
-            code = _linear_decompress_code
+    if interpolation == "inline_linear":
+        if amp_freq != None:
+           raise ValueError("for inline_linear_single_freq decompression"
+       		            "amp_freq should be set to None as it should"
+		            "be the same as phase_freq")
+	if amp_freq == None:
+	    imin = int(numpy.searchsorted(sample_frequencies, f_lower))
+            if precision == 'single':
+                code = _linear_decompress_code32
+            else:
+                code = _linear_decompress_code
         # use custom interpolation
-        sflen = len(sample_frequencies)
-        h = numpy.array(out.data, copy=False)
-        delta_f = float(df)
-        inline(code, ['h', 'hlen', 'sflen', 'delta_f', 'sample_frequencies',
-                      'amp', 'phase', 'start_index', 'imin'],
-               extra_compile_args=[WEAVE_FLAGS + '-march=native -O3 -w'] +\
-                                  omp_flags,
-               libraries=omp_libs)
+            sflen = len(sample_frequencies)
+            h = numpy.array(out.data, copy=False)
+            delta_f = float(df)
+            inline(code, ['h', 'hlen', 'sflen', 'delta_f', 'sample_frequencies',
+                          'amp', 'phase', 'start_index', 'imin'],
+                   extra_compile_args=[WEAVE_FLAGS + '-march=native -O3 -w'] +\
+                   omp_flags, libraries=omp_libs)
     else:
+        if amp_freq == None:
+        	amp_freq = phase_freq
         # use scipy for fancier interpolation
         outfreq = out.sample_frequencies.numpy()
-        amp_interp = interpolate.interp1d(amp_freq.numpy(),
-            amp.numpy(), kind=interpolation, bounds_error=False, fill_value=0.,
-            assume_sorted=True)
-        phase_interp = interpolate.interp1d(phase_freq.numpy(),
-            phase.numpy(), kind=interpolation, bounds_error=False,
-            fill_value=0., assume_sorted=True)
+        amp_interp = interpolate.interp1d(
+                        amp_freq, amp, kind=interpolation,
+                        bounds_error=False, fill_value=0.,
+                        assume_sorted=True)
+        phase_interp = interpolate.interp1d(
+                        phase_freq, phase, kind=interpolation,
+                        bounds_error=False, fill_value=0.,
+                        assume_sorted=True)
         A = amp_interp(outfreq)
         phi = phase_interp(outfreq)
         out.data[:] = A*numpy.cos(phi) + (1j)*A*numpy.sin(phi)
@@ -553,57 +626,60 @@ def fd_decompress(amp, phase, amp_freq, phase_freq, out=None, df=None,
 
 class CompressedWaveform(object):
     """Class that stores information about a compressed waveform.
-    
+
     Parameters
     ----------
     amplitude_freq_points : {array, h5py.Dataset}
-        The frequency points at which the amplitude of the compressed waveform is sampled.
+        The frequency points at which the amplitude of the compressed
+        waveform is sampled.
     phase_freq_points : {array, h5py.Dataset}
-        The frequency points at which the phase of the compressed waveform is sampled.
+        The frequency points at which the phase of the compressed
+        waveform is sampled.
     amplitude : {array, h5py.Dataset}
         The amplitude of the waveform at the given `sample_points`.
     phase : {array, h5py.Dataset}
         The phase of the waveform at the given `sample_points`.
     interpolation : {None, str}
         The interpolation that was used when compressing the waveform for
-        computing tolerance. This is also the default interpolation used when
-        decompressing; see `decompress` for details.
+        computing tolerance. This is also the default interpolation used
+        when decompressing; see `decompress` for details.
     tolerance : {None, float}
         The tolerance that was used when compressing the waveform.
     mismatch : {None, float}
-        The actual mismatch between the decompressed waveform (using the given
-        `interpolation`) and the full waveform.
+        The actual mismatch between the decompressed waveform (using the
+        given `interpolation`) and the full waveform.
     load_to_memory : {True, bool}
-        If `sample_points`, `amplitude`, and/or `phase` is an hdf dataset, they
-        will be cached in memory the first time they are accessed. Default is
-        True.
+        If `sample_points`, `amplitude`, and/or `phase` is an hdf dataset,
+        they will be cached in memory the first time they are accessed.
+        Default is True.
 
     Attributes
     ----------
     amplitude_freq_points : array
         The frequencies at which the amplitude of the compressed waveform is
         sampled. This is always returned as an array, even if the stored
-        `sample_points` is an hdf dataset. If `load_to_memory` is True and the
-        stored points are an hdf dataset, the `sample_points` will cached in
-        memory the first time this attribute is accessed.
+        `sample_points` is an hdf dataset. If `load_to_memory` is True
+        and the stored points are an hdf dataset, the `sample_points`
+        will cached in memory the first time this attribute is accessed.
     phase_freq_points : array
         The frequencies at which the phase of the compressed waveform is
-        sampled. This is always returned as an array, even if the stored
-        `sample_points` is an hdf dataset. If `load_to_memory` is True and the
-        stored points are an hdf dataset, the `sample_points` will cached in
-        memory the first time this attribute is accessed.
+        sampled. This is always returned as an array; the same logic as
+        for `amplitude_freq_points` is used to determine whether or not
+        to cache in memory.
     amplitude : array
-        The amplitude of the waveform at the `sample_points`. This is always
-        returned as an array; the same logic as for `sample_points` is used
-        to determine whether or not to cache in memory.
+        The amplitude of the waveform at the `amplitude_freq_points`.
+        This is always returned as an array; the same logic as for
+        `amplitude_freq_points` is used to determine whether or not to
+        cache in memory.
     phase : array
-        The phase of the waveform as the `sample_points`. This is always
-        returned as an array; the same logic as for `sample_points` is used to
-        determine whether or not to cache in memory.
+        The phase of the waveform as the `phase_freq_points`. This is
+        always returned as an array; the same logic as for
+        `amplitude_freq_points` is used to determine whether or not to
+        cache in memory.
     load_to_memory : bool
-        Whether or not to load `sample_points`/`amplitude`/`phase` into memory
-        the first time they are accessed, if they are hdf datasets. Can be
-        set directly to toggle this behavior.
+        Whether or not to load `sample_points`/`amplitude`/`phase` into
+        memory the first time they are accessed, if they are hdf datasets.
+        Can be set directly to toggle this behavior.
     interpolation : str
         The interpolation that was used when compressing the waveform, for
         checking the mismatch. Also the default interpolation used when
@@ -622,7 +698,7 @@ class CompressedWaveform(object):
         Writes the compressed waveform to an open hdf file.
     clear_cache :
         Clears the in-memory cache used to hold the
-        `amplitude_freq_points`/`phase_freq_points`/`amplitude`/`phase`; 
+        `amplitude_freq_points`/`phase_freq_points`/`amplitude`/`phase`;
         only relevant if `load_to_memory` is True.
 
     Class Methods
@@ -630,11 +706,10 @@ class CompressedWaveform(object):
     from_hdf :
         Loads a compressed waveform from the given open hdf file.
     """
-    
-    def __init__(self, 
-            amplitude_freq_points, phase_freq_points, amplitude, phase,
-            interpolation=None, tolerance=None, mismatch=None,
-            load_to_memory=True):
+
+    def __init__(self, amplitude_freq_points, phase_freq_points,
+                 amplitude, phase, interpolation, tolerance=None,
+                 mismatch=None, load_to_memory=False):
         self._amplitude_freq_points = amplitude_freq_points
         self._phase_freq_points = phase_freq_points
         self._amplitude = amplitude
@@ -679,24 +754,24 @@ class CompressedWaveform(object):
 
     def decompress(self, out=None, df=None, f_lower=None, interpolation=None):
         """Decompress self.
-        
+
         Parameters
         ----------
         out : {None, FrequencySeries}
-            Write the decompressed waveform to the given frequency series. The
-            decompressed waveform will have the same `delta_f` as `out`.
+            Write the decompressed waveform to the given frequency series.
+            The decompressed waveform will have the same `delta_f` as `out`.
             Either this or `df` must be provided.
         df : {None, float}
             Decompress the waveform such that its `delta_f` has the given
             value. Either this or `out` must be provided.
         f_lower : {None, float}
-            The starting frequency at which to decompress the waveform. Cannot
-            be less than the minimum frequency of either
+            The starting frequency at which to decompress the waveform.
+            Cannot be less than the minimum frequency of either
             `amplitude_freq_points` or `phase_freq_points`. If `None`
             provided, will default to the minimum frequency available.
-        interpolation : {None, str}
-            The interpolation to use for decompressing the waveform. If `None`
-            provided, will default to `self.interpolation`.
+        interpolation : {interpolation, str}
+            The interpolation to use for decompressing the waveform. If
+            `None` provided, will default to `self.interpolation`.
 
         Returns
         -------
@@ -706,21 +781,27 @@ class CompressedWaveform(object):
         if f_lower is None:
             # use the minimum of the sample points
             f_lower = numpy.array([self.amplitude_freq_points.min(),
-                       self.phase_freq_points.min()]).max()
+                                  self.phase_freq_points.min()]).max()
         if interpolation is None:
             interpolation = self.interpolation
-        return fd_decompress(self.amplitude, self.phase, 
-            self.amplitude_freq_points, self.phase_freq_points,
-            out=out, df=df, f_lower=f_lower, interpolation=interpolation)
+        return fd_decompress(self.amplitude, self.phase,
+                             self.amplitude_freq_points,
+                             self.phase_freq_points, out=out, df=df,
+                             f_lower=f_lower, interpolation=interpolation)
 
     def write_to_hdf(self, fp, template_hash, root=None):
         """Write the compressed waveform to the given hdf file handler.
 
         The waveform is written to:
         `fp['[{root}/]compressed_waveforms/{template_hash}/{param}']`,
-        where `param` is the `amplitude_freq_points`, `phase_freq_points`, 
-        `amplitude`, and `phase`. The `interpolation`, `tolerance`, and
-        `mismatch` are saved to the group's attributes.
+        where `param` is the `amplitude_freq_points`, `phase_freq_points`,
+        `amplitude`, and `phase`. If the frequency points for amplitude
+        interpolants and phase interpolants are the same, write only the
+        phase frequency points set to the hdf file. If the frequency
+        points for amplitude interpolants and phase interpolants are,
+        different, write both of those sets to the hdf file.
+        The `interpolation`, `tolerance`, and `mismatch` are saved to
+        the group's attributes.
 
         Parameters
         ----------
@@ -729,28 +810,29 @@ class CompressedWaveform(object):
         template_hash : {hash, int, str}
             A hash, int, or string to map the template to the waveform.
         root : {None, str}
-            Put the `compressed_waveforms` group in the given directory in the
-            hdf file. If `None`, `compressed_waveforms` will be the root
-            directory.
+            Put the `compressed_waveforms` group in the given directory
+            in the hdf file. If `None`, `compressed_waveforms` will be
+            the root directory.
         """
         if root is None:
             root = ''
         else:
             root = '%s/'%(root)
         group = '%scompressed_waveforms/%s' %(root, str(template_hash))
-        if self.interpolation == "linear":
-           for param in ['amplitude', 'phase', 'phase_freq_points']:
-               fp['%s/%s' %(group, param)] = self._get(param)
-        else:
-           for param in ['amplitude', 'phase', 'amplitude_freq_ponts', 'phase_freq_points']:
-               fp['%s/%s' %(group, param)] = self._get(param)
+        if self.amplitude_freq_points == None:
+            for param in ['amplitude', 'phase', 'phase_freq_points']:
+                fp['%s/%s' %(group, param)] = self._get(param)
+            fp[group].attrs['tolerance'] = self.tolerance
+	else:
+	    for param in ['amplitude', 'phase', 'amplitude_freq_points',
+                          'phase_freq_points']:
+                fp['%s/%s' %(group, param)] = self._get(param)
         fp[group].attrs['mismatch'] = self.mismatch
         fp[group].attrs['interpolation'] = self.interpolation
-        fp[group].attrs['tolerance'] = self.tolerance
 
     @classmethod
     def from_hdf(cls, fp, template_hash, root=None, load_to_memory=True,
-            load_now=False):
+                 load_now=False):
         """Load a compressed waveform from the given hdf file handler.
 
         The waveform is retrieved from:
@@ -768,7 +850,7 @@ class CompressedWaveform(object):
             Retrieve the `compressed_waveforms` group from the given string.
             If `None`, `compressed_waveforms` will be assumed to be in the
             top level.
-        load_to_memory : {True, bool}
+        load_to_memory : {False, bool}
             Set the `load_to_memory` attribute to the given value in the
             returned instance.
         load_now : {False, bool}
@@ -786,18 +868,30 @@ class CompressedWaveform(object):
         else:
             root = '%s/'%(root)
         group = '%scompressed_waveforms/%s' %(root, str(template_hash))
-        amplitude_freq = fp[group]['amplitude_freq_points']
-        phase_freq = fp[group]['phase_freq_points']
-        amp = fp[group]['amplitude']
-        phase = fp[group]['phase']
-        if load_now:
-            amplitude_freq = amplitude_freq[:]
-            phase_freq = phase_freq[:]
-            amp = amp[:]
-            phase = phase[:]
+        if fp[group]['amplitude_freq_points'] :
+            amplitude_freq = fp[group]['amplitude_freq_points']
+            phase_freq = fp[group]['phase_freq_points']
+            amp = fp[group]['amplitude']
+            phase = fp[group]['phase']
+            tolerance = None
+            if load_now:
+                amplitude_freq = amplitude_freq[:]
+                phase_freq = phase_freq[:]
+                amp = amp[:]
+                phase = phase[:]
+        else :
+            amplitude_freq = None
+            phase_freq = fp[group]['phase_freq_points']
+            amp = fp[group]['amplitude']
+            phase = fp[group]['phase']
+            tolerance = fp[group].attrs['tolerance']
+            if load_now:
+                phase_freq = phase_freq[:]
+                amp = amp[:]
+                phase = phase[:]
         return cls(amplitude_freq, phase_freq, amp, phase,
-            interpolation=fp[group].attrs['interpolation'],
-            tolerance=fp[group].attrs['tolerance'],
-            mismatch=fp[group].attrs['mismatch'],
-            load_to_memory=load_to_memory)
+                   interpolation=fp[group].attrs['interpolation'],
+                   tolerance=tolerance,
+                   mismatch=fp[group].attrs['mismatch'],
+                   load_to_memory=load_to_memory)
 


### PR DESCRIPTION
This commit adds in the partial ROM compression method to the code.
- A new argument ROM-parameter-space-interpolation has been added to pycbc_compress_bank which takes in options linear_compression or partial_ROM_compression, for the user to choose the method to use to perform the parameter space interpolation for the ROM templates.
- A new function partial_compress_rom has been added to compress.py to fetch the amplitude and phase parameter space interpolants from the SEOBNRv2_ROM LAL code, call fd_decompress to perform the frequency space interpolation, calculate the mismatch between the interpolated waveform and the full decompressed SEOBNRv2_ROM waveform and create an instance of CompressedWaveform with the required arguments.
- The code generates amplitude_freq_points arrays only for the partial_ROM_compression method. For a choice of linear_compression regardless of the kind of template, amplitude_freq_points has been considered None .
- The output hdf file would save amplitude, phase, amplitude_freq_points, and phase_freq_points as keys() and interpolation, mismatch as the group attributes for the partial_ROM_compression case in which amplitude_freq_points and phase_freq_points are not the same. For linear_compression for both SEOBNRv2_ROM and TaylorF2 templates, the output hdf file would save amplitude, phase, and phase_freq_points as keys() ( because amplitude_freq_points and phase_freq_points are the same in such cases ) and interpolation, mismatch, tolerance as the group attributes. 

@duncan-brown Could you please check this modified code?
